### PR TITLE
feat: 新增 vitepress-like Custom Container

### DIFF
--- a/.vitepress/theme/index.js
+++ b/.vitepress/theme/index.js
@@ -1,6 +1,13 @@
 // .vitepress/theme/index.js
 import './tailwind.postcss';
-import DefaultTheme from 'vitepress/theme';
 import './custom.css';
+import DefaultTheme from 'vitepress/theme';
+import CustomContainer from '../../src/components/CustomContainer.vue';
 
-export default { ...DefaultTheme };
+/** @type {import('vitepress').Theme} */
+export default {
+  extends: DefaultTheme,
+  enhanceApp({ app }) {
+    app.component('CustomContainer', CustomContainer);
+  },
+};

--- a/src/components/CustomContainer.vue
+++ b/src/components/CustomContainer.vue
@@ -1,0 +1,18 @@
+<!-- fake custom component: https://github.com/vuejs/vitepress/blob/main/src/node/markdown/plugins/containers.ts -->
+<script setup>
+const props = defineProps({
+  type: String,
+  title: String,
+})
+</script>
+
+<template>
+  <details v-if="props.type === 'details'">
+    <summary :class="[props.type, 'custom-block']">{{ props.title }}</summary>
+    <p><slot /></p>
+  </details>
+  <div :class="[props.type, 'custom-block']" v-else>
+    <p class="custom-block-title">{{ props.title }}</p>
+    <p><slot /></p>
+  </div>
+</template>

--- a/src/components/CustomContainer.vue
+++ b/src/components/CustomContainer.vue
@@ -1,18 +1,31 @@
 <!-- fake custom component: https://github.com/vuejs/vitepress/blob/main/src/node/markdown/plugins/containers.ts -->
 <script setup>
+import { computed } from 'vue';
+
 const props = defineProps({
-  type: String,
-  title: String,
+  type: {
+    type: String,
+    required: true,
+  },
+  title: {
+    type: String,
+    default: '',
+  },
 })
+
+const computedTitle = computed(() => {
+  return props.title || props.type[0].toUpperCase() + props.type.slice(1)
+})
+
 </script>
 
 <template>
   <details v-if="props.type === 'details'">
-    <summary :class="[props.type, 'custom-block']">{{ props.title }}</summary>
+    <summary :class="[props.type, 'custom-block']">{{ computedTitle }}</summary>
     <p><slot /></p>
   </details>
   <div :class="[props.type, 'custom-block']" v-else>
-    <p class="custom-block-title">{{ props.title }}</p>
+    <p class="custom-block-title">{{ computedTitle }}</p>
     <p><slot /></p>
   </div>
 </template>


### PR DESCRIPTION
像是 vitepress markdown extension 一樣的 container box，型別如下：

```typescript
interface Props {
  type: "info" | "tip" | "warning" | "danger" | "details";
  tilte?: string;
}
```
![image](https://github.com/Legislature-for-deermocracy/Legislature-for-deermocracy-web/assets/5199594/fc411582-9775-4765-8b64-61e57ec2b0f4)

![image](https://github.com/Legislature-for-deermocracy/Legislature-for-deermocracy-web/assets/5199594/b78a83df-353a-4a7c-8378-9435072f9cc9)
